### PR TITLE
Add Telegram bot and notification endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # PiAPS_curse
+
+This project is a Flask-based API and web application. A simple Telegram bot is provided to interact with the same API.
+
+## Telegram bot
+
+The bot allows a user to authenticate using the `/login` command and fetch notifications via `/notifications`.
+
+### Running the bot
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Export required variables:
+   ```bash
+   export TELEGRAM_BOT_TOKEN=<your_bot_token>
+   export API_URL=http://localhost:5000  # change if API hosted elsewhere
+   ```
+3. Start the bot:
+   ```bash
+   python bot/telegram_bot.py
+   ```
+
+The bot uses the same endpoints as the web application and requires the API server to be running.

--- a/app/api/notification_controller.py
+++ b/app/api/notification_controller.py
@@ -1,5 +1,22 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.notification_service import NotificationService
 
 notification_bp = Blueprint("notification", __name__)
 
-# listSettings, updateSetting, sendTest
+@notification_bp.route("/", methods=["GET"])
+@jwt_required()
+def list_notifications():
+    user_id = int(get_jwt_identity())
+    notifications = NotificationService.list_notifications(user_id)
+    return jsonify(notifications), 200
+
+@notification_bp.route("/test", methods=["POST"])
+@jwt_required()
+def create_test_notification():
+    user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+    event = data.get("event", "Test notification")
+    notification = NotificationService.create_notification(user_id, event)
+    return jsonify(notification), 201

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1,0 +1,27 @@
+from app.main.extensions import db
+from app.models.notification import Notification
+
+class NotificationService:
+    @staticmethod
+    def create_notification(user_id: int, event: str):
+        notification = Notification(user_id=user_id, event=event)
+        db.session.add(notification)
+        db.session.commit()
+        return {
+            "id": notification.id,
+            "user_id": user_id,
+            "event": event,
+            "sent_at": notification.sent_at.isoformat() if notification.sent_at else None
+        }
+
+    @staticmethod
+    def list_notifications(user_id: int):
+        notifications = Notification.query.filter_by(user_id=user_id).order_by(Notification.sent_at.desc()).all()
+        return [
+            {
+                "id": n.id,
+                "event": n.event,
+                "sent_at": n.sent_at.isoformat() if n.sent_at else None
+            }
+            for n in notifications
+        ]

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -1,0 +1,88 @@
+import logging
+import os
+from typing import Tuple
+
+import requests
+from telegram import Update
+from telegram.ext import (ApplicationBuilder, CommandHandler, ContextTypes,
+                          ConversationHandler, MessageHandler, filters)
+
+API_URL = os.getenv("API_URL", "http://localhost:5000")
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+LOGIN_EMAIL, LOGIN_PASSWORD = range(2)
+
+user_tokens = {}
+
+
+def login_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    update.message.reply_text("Введите email")
+    return LOGIN_EMAIL
+
+
+def login_email(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data['email'] = update.message.text.strip()
+    update.message.reply_text("Введите пароль")
+    return LOGIN_PASSWORD
+
+
+def login_password(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    password = update.message.text.strip()
+    email = context.user_data.get('email')
+    resp = requests.post(f"{API_URL}/api/auth/login", json={"email": email, "password": password})
+    if resp.status_code == 200:
+        data = resp.json()
+        user_tokens[update.effective_user.id] = data['access_token']
+        update.message.reply_text("Успешный вход")
+    else:
+        update.message.reply_text("Ошибка авторизации")
+    return ConversationHandler.END
+
+
+def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    update.message.reply_text("Отменено")
+    return ConversationHandler.END
+
+
+def get_notifications(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    token = user_tokens.get(update.effective_user.id)
+    if not token:
+        update.message.reply_text("Сначала выполните /login")
+        return
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.get(f"{API_URL}/api/notifications/", headers=headers)
+    if resp.status_code == 200:
+        notifications = resp.json()
+        if not notifications:
+            update.message.reply_text("Новых уведомлений нет")
+        else:
+            for n in notifications:
+                update.message.reply_text(f"{n['sent_at']}: {n['event']}")
+    else:
+        update.message.reply_text("Ошибка получения уведомлений")
+
+
+def main() -> None:
+    if not BOT_TOKEN:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN not set")
+    application = ApplicationBuilder().token(BOT_TOKEN).build()
+
+    conv = ConversationHandler(
+        entry_points=[CommandHandler('login', login_start)],
+        states={
+            LOGIN_EMAIL: [MessageHandler(filters.TEXT & ~filters.COMMAND, login_email)],
+            LOGIN_PASSWORD: [MessageHandler(filters.TEXT & ~filters.COMMAND, login_password)],
+        },
+        fallbacks=[CommandHandler('cancel', cancel)],
+    )
+    application.add_handler(conv)
+    application.add_handler(CommandHandler('notifications', get_notifications))
+
+    application.run_polling()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ flask-marshmallow
 flask_wtf
 email_validator
 marshmallow-sqlalchemy
+requests
+python-telegram-bot~=20.6


### PR DESCRIPTION
## Summary
- implement telegram bot using python-telegram-bot
- add notification API endpoints and service
- document bot usage in README
- add required dependencies

## Testing
- `python -m compileall -q app bot`
- `python -m py_compile bot/telegram_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684073ed118c832d88c4bc775b5f723f