### PR TITLE
Fix owner code uniqueness including USED codes

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -22,7 +22,10 @@ class AdminAddressForm(FlaskForm):
     street = StringField("Улица", validators=[DataRequired()])
     building = StringField("Дом", validators=[DataRequired()])
     unit = StringField("Квартира", validators=[DataRequired()])
-    code = StringField("Уникальный код", validators=[DataRequired(), Length(max=64)])
+    code = StringField(
+        "Уникальный код",
+        validators=[DataRequired(), Length(min=6, max=64)]
+    )
     submit = SubmitField("Создать")
 
     def validate_code(self, field):

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,7 +1,8 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField, BooleanField
 from wtforms.fields import EmailField
-from wtforms.validators import DataRequired, Email, Length, Optional
+from wtforms.validators import DataRequired, Email, Length, Optional, ValidationError
+from app.models.address import Address
 
 
 class RegisterForm(FlaskForm):
@@ -23,6 +24,15 @@ class AdminAddressForm(FlaskForm):
     unit = StringField("Квартира", validators=[DataRequired()])
     code = StringField("Уникальный код", validators=[DataRequired(), Length(max=64)])
     submit = SubmitField("Создать")
+
+    def validate_code(self, field):
+        code = field.data
+        used_code = f"USED_{code}"
+        existing = Address.query.filter(
+            (Address.owner_code == code) | (Address.owner_code == used_code)
+        ).first()
+        if existing:
+            raise ValidationError("Код уже используется")
 
 
 class InviteForm(FlaskForm):


### PR DESCRIPTION
## Summary
- prevent admin from reusing a code that was already used
- validate owner code uniqueness in `AdminAddressForm`
- show an error when creating an address with an existing or USED code

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841755b0d50832d9ccdc326a1f4ca8f