### PR TITLE
Switch resident deletion to block/unblock

### DIFF
--- a/app/api/notification_controller.py
+++ b/app/api/notification_controller.py
@@ -18,13 +18,15 @@ def _format_message(event: str) -> str:
                 f"{inviter.name} пригласил вас на адрес "
                 f"{addr.street} {addr.building_number}, кв. {addr.unit_number}"
             )
-    elif parts[0] in {"resident_added", "resident_removed", "role_changed"} and len(parts) >= 2:
+    elif parts[0] in {"resident_added", "resident_removed", "role_changed", "resident_blocked", "resident_unblocked"} and len(parts) >= 2:
         addr = Address.query.get(int(parts[1]))
         if addr:
             changes = {
                 "resident_added": "добавлен новый жилец",
                 "resident_removed": "жилец удалён",
                 "role_changed": "изменена роль жильца",
+                "resident_blocked": "жилец заблокирован",
+                "resident_unblocked": "жилец разблокирован",
             }
             return (
                 f"На адресе {addr.street} {addr.building_number}, кв. {addr.unit_number} "

--- a/app/api/resident_controller.py
+++ b/app/api/resident_controller.py
@@ -16,13 +16,13 @@ def list_residents(address_id):
         return jsonify({"error": str(e)}), 403
 
 
-@resident_bp.route("/<int:address_id>/<int:target_user_id>/block", methods=["PUT"])
+@resident_bp.route("/<int:address_id>/<int:target_user_id>/toggle-block", methods=["PUT"])
 @jwt_required()
-def block_resident(address_id, target_user_id):
+def toggle_block_resident(address_id, target_user_id):
     user_id = int(get_jwt_identity())
     try:
         ResidentService.block_resident(user_id, address_id, target_user_id)
-        return jsonify({"message": "Resident blocked"}), 200
+        return jsonify({"message": "Resident block toggled"}), 200
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
 

--- a/app/models/user_address.py
+++ b/app/models/user_address.py
@@ -10,6 +10,7 @@ class UserAddress(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     address_id = db.Column(db.Integer, db.ForeignKey("addresses.id"), nullable=False)
     role = db.Column(Enum(ResidentRole), nullable=False, default=ResidentRole.RESIDENT)
+    is_blocked = db.Column(db.Boolean, default=False)
 
     user = relationship("User", back_populates="addresses")
     address = relationship("Address", back_populates="residents")

--- a/app/services/resident_service.py
+++ b/app/services/resident_service.py
@@ -25,7 +25,8 @@ class ResidentService:
                 "user_id": r.user.id,
                 "name": r.user.name,
                 "email": r.user.email,
-                "role": r.role.value
+                "role": r.role.value,
+                "is_blocked": getattr(r, "is_blocked", False),
             }
             for r in residents
         ]
@@ -42,12 +43,12 @@ class ResidentService:
         if not target:
             raise ValueError("User not found in this address")
 
-        db.session.delete(target)
+        target.is_blocked = not getattr(target, "is_blocked", False)
         db.session.commit()
 
         NotificationService.notify_resident_change(
             address_id,
-            "resident_removed",
+            "resident_blocked" if target.is_blocked else "resident_unblocked",
             exclude_user_id=target_user_id,
         )
 

--- a/app/templates/address_residents.html
+++ b/app/templates/address_residents.html
@@ -21,7 +21,12 @@
     <tr>
       <td>{{ r.user.name }}</td>
       <td>{{ r.user.email }}</td>
-      <td>{{ r.role.value }}</td>
+      <td>
+        {{ r.role.value }}
+        {% if r.is_blocked %}
+        <span class="badge bg-danger">Блок</span>
+        {% endif %}
+      </td>
       {% if user_role == "ADMIN" or user_role == 'OWNER' %}
       <td>
         {% if r.user.id != current_user_id %}
@@ -33,8 +38,10 @@
           </select>
           <button class="btn btn-sm btn-primary">Сменить</button>
         </form>
-        <form method="POST" action="{{ url_for('web.remove_resident', resident_id=r.id) }}" class="d-inline ms-2">
-          <button class="btn btn-sm btn-danger">Удалить</button>
+        <form method="POST" action="{{ url_for('web.toggle_resident_block', resident_id=r.id) }}" class="d-inline ms-2">
+          <button class="btn btn-sm btn-{{ 'danger' if not r.is_blocked else 'success' }}">
+            {% if r.is_blocked %}Разблокировать{% else %}Заблокировать{% endif %}
+          </button>
         </form>
         {% endif %}
       </td>

--- a/migrations/versions/d10f1eacb4d2_add_resident_blocking.py
+++ b/migrations/versions/d10f1eacb4d2_add_resident_blocking.py
@@ -1,0 +1,23 @@
+"""add resident blocking
+
+Revision ID: d10f1eacb4d2
+Revises: c7421d9b1c4a
+Create Date: 2025-06-05 00:00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'd10f1eacb4d2'
+down_revision = 'c7421d9b1c4a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user_addresses', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_blocked', sa.Boolean(), nullable=True, server_default=sa.text('false')))
+
+
+def downgrade():
+    with op.batch_alter_table('user_addresses', schema=None) as batch_op:
+        batch_op.drop_column('is_blocked')


### PR DESCRIPTION
## Summary
- add `is_blocked` flag to `UserAddress`
- allow owners to block/unblock residents via a new route and button
- update resident listing and notification messages
- provide migration for new column

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684179417bfc832d9ae8425b0cce0785